### PR TITLE
Add observability to help with debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ version = "0.1.0"
 dependencies = [
  "frontend",
  "text-size",
+ "tracing",
  "wasm-encoder",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,8 @@ dependencies = [
  "clap",
  "frontend",
  "language-server",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -281,6 +283,7 @@ dependencies = [
  "num-traits",
  "rowan",
  "text-size",
+ "tracing",
  "yansi",
 ]
 
@@ -508,6 +511,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,10 +547,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "proc-macro2"
@@ -651,10 +676,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "similar"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "strsim"
@@ -680,6 +720,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +743,63 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
 
 [[package]]
 name = "ungrammar"
@@ -744,6 +851,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "walkdir"
@@ -850,6 +963,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +986,12 @@ checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -8,3 +8,7 @@ license = "MIT"
 text-size = "1.1.1"
 wasm-encoder = "0.209"
 frontend = { path = "../frontend" }
+tracing = { version = "0.1.40", features = [
+    "max_level_debug",
+    "release_max_level_warn",
+] }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -568,6 +568,7 @@ impl<'a> Codegen<'a> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self), ret)]
     fn instantiate_polyfunc(&mut self, name: Name, ty_params: &Substitution) -> Name {
         let new_name = {
             let poly_func = self.poly_funcs.get_mut(&name).expect("Unknown polyfunc");

--- a/crates/backend/src/wasm_builder.rs
+++ b/crates/backend/src/wasm_builder.rs
@@ -732,6 +732,7 @@ impl<'a> Builder<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct BodyBuilder {
     param_count: usize,
     locals: Vec<ValType>,

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,5 +12,8 @@ clap = { version = "4.4.12", features = ["derive"] }
 frontend = { path = "../frontend" }
 backend = { path = "../backend" }
 language-server = { path = "../language-server" }
-tracing = "0.1.40"
+tracing = { version = "0.1.40", features = [
+    "max_level_debug",
+    "release_max_level_warn",
+] }
 tracing-subscriber = "0.3.18"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,3 +12,5 @@ clap = { version = "4.4.12", features = ["derive"] }
 frontend = { path = "../frontend" }
 backend = { path = "../backend" }
 language-server = { path = "../language-server" }
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,7 @@ use backend::compile_program;
 use clap::{Parser, Subcommand};
 use language_server::start_language_server;
 use std::{error::Error, fs, path::PathBuf};
+use tracing_subscriber;
 
 /// The nemo language
 #[derive(Debug, Parser)]
@@ -40,8 +41,8 @@ fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
     match args.command {
         Commands::Compile { input_file, output } => {
             let source = fs::read_to_string(&input_file)?;
-            let wasm =
-                tracing::info_span!("compile_program").in_scope(|| compile_program(&source))?;
+            let _span = tracing::debug_span!("compile", file = %input_file.display()).entered();
+            let wasm = compile_program(&source)?;
             let output_file = output.unwrap_or_else(|| input_file.with_extension("wasm"));
             fs::write(output_file, wasm)?;
             Ok(())

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -35,11 +35,13 @@ enum Commands {
 }
 
 fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
+    tracing_subscriber::fmt::init();
     let args = Cli::parse();
     match args.command {
         Commands::Compile { input_file, output } => {
             let source = fs::read_to_string(&input_file)?;
-            let wasm = compile_program(&source)?;
+            let wasm =
+                tracing::info_span!("compile_program").in_scope(|| compile_program(&source))?;
             let output_file = output.unwrap_or_else(|| input_file.with_extension("wasm"));
             fs::write(output_file, wasm)?;
             Ok(())

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -16,6 +16,7 @@ text-size = "1.1.1"
 line-index = "0.1.1"
 lexpr = "0.2.7"
 derive_ir = { path = "../derive_ir" }
+tracing = "0.1.40"
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["glob"] }

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -16,7 +16,10 @@ text-size = "1.1.1"
 line-index = "0.1.1"
 lexpr = "0.2.7"
 derive_ir = { path = "../derive_ir" }
-tracing = "0.1.40"
+tracing = { version = "0.1.40", features = [
+    "max_level_debug",
+    "release_max_level_warn",
+] }
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["glob"] }

--- a/crates/frontend/src/ir.rs
+++ b/crates/frontend/src/ir.rs
@@ -412,6 +412,21 @@ impl Expr {
         free_vars_inner(&mut results, self);
         results
     }
+
+    pub fn display<'a>(&'a self, names: &'a NameSupply) -> ExprDisplay<'a> {
+        ExprDisplay { names, expr: self }
+    }
+}
+
+pub struct ExprDisplay<'a> {
+    names: &'a NameSupply,
+    expr: &'a Expr,
+}
+
+impl fmt::Display for ExprDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", format::expr(self.names, &self.expr))
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -485,6 +500,17 @@ pub struct Declaration {
     pub ty: Ty,
 }
 
+pub struct DeclarationDisplay<'a> {
+    names: &'a NameSupply,
+    inner: &'a Declaration,
+}
+
+impl fmt::Display for DeclarationDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", format::decl(self.names, self.inner))
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, IrBuilder)]
 pub enum DeclarationData {
     Let { binder: Name, expr: Expr },
@@ -498,6 +524,17 @@ pub struct SetTarget {
     pub it: SetTargetData,
     pub at: TextRange,
     pub ty: Ty,
+}
+
+pub struct SetTargetDisplay<'a> {
+    names: &'a NameSupply,
+    inner: &'a SetTarget,
+}
+
+impl fmt::Display for SetTargetDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", format::set_target(self.names, self.inner))
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, IrBuilder)]

--- a/crates/frontend/src/ir/format.rs
+++ b/crates/frontend/src/ir/format.rs
@@ -4,8 +4,24 @@ use crate::ir::{
 };
 use lexpr::Value;
 
-pub fn format_ir(names: &NameSupply, ir: &Program) -> String {
+pub fn prog(names: &NameSupply, ir: &Program) -> String {
     format!("{}", Formatter { names }.program(ir))
+}
+
+pub fn expr(names: &NameSupply, expr: &Expr) -> String {
+    format!("{}", Formatter { names }.expr(expr))
+}
+
+pub fn decl(names: &NameSupply, decl: &Declaration) -> String {
+    format!("{}", Formatter { names }.decl(decl))
+}
+
+pub fn set_target(names: &NameSupply, set_target: &SetTarget) -> String {
+    format!("{}", Formatter { names }.set_target(set_target))
+}
+
+pub fn ty(names: &NameSupply, ty: &Ty) -> String {
+    format!("{}", Formatter { names }.ty(ty))
 }
 
 struct Formatter<'a> {
@@ -156,6 +172,7 @@ impl Formatter<'_> {
             ExprData::Return { expr } => Value::list(vec!["return".into(), self.expr(expr)]),
         }
     }
+
     fn program(&self, program: &Program) -> Value {
         let mut elems = vec![Value::symbol("program")];
         elems.extend(program.funcs.iter().map(|f| self.expr(&f.body)));

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -8,7 +8,6 @@ pub mod types;
 
 use parser::parse_prog;
 
-use crate::ir::format::format_ir;
 pub use error::CheckError;
 pub use types::CheckResult;
 
@@ -29,9 +28,6 @@ pub fn run_frontend(source: &str) -> CheckResult<CheckError> {
     if errors.is_empty() && check_result.ir.is_none() {
         panic!("No IR generated, despite no errors")
     };
-    if let Some(ir) = &check_result.ir {
-        println!("{}", format_ir(&check_result.names, ir));
-    }
 
     CheckResult {
         errors,

--- a/crates/frontend/src/types/error.rs
+++ b/crates/frontend/src/types/error.rs
@@ -18,24 +18,24 @@ impl TyErrors {
 
     pub fn report<N: HasRange>(&mut self, node: &N, error: TyErrorData) {
         self.errors.push(TyError {
-            at: node.to_range(),
+            at: node.range(),
             it: error,
         })
     }
 }
 
 pub trait HasRange {
-    fn to_range(&self) -> TextRange;
+    fn range(&self) -> TextRange;
 }
 
 impl<N: AstNode> HasRange for N {
-    fn to_range(&self) -> TextRange {
-        self.syntax().to_range()
+    fn range(&self) -> TextRange {
+        self.syntax().range()
     }
 }
 
 impl HasRange for SyntaxNode {
-    fn to_range(&self) -> TextRange {
+    fn range(&self) -> TextRange {
         let at = self.text_range();
         let mut start = at.start();
         let mut end = at.end();
@@ -58,13 +58,13 @@ impl HasRange for SyntaxNode {
 }
 
 impl HasRange for SyntaxToken {
-    fn to_range(&self) -> TextRange {
+    fn range(&self) -> TextRange {
         self.text_range()
     }
 }
 
 impl HasRange for TextRange {
-    fn to_range(&self) -> TextRange {
+    fn range(&self) -> TextRange {
         *self
     }
 }

--- a/crates/frontend/src/types/names.rs
+++ b/crates/frontend/src/types/names.rs
@@ -17,6 +17,10 @@ impl NameSupply {
         Self::default()
     }
 
+    pub fn inner(&self) -> &ir::NameSupply {
+        &self.0
+    }
+
     pub fn take(self) -> ir::NameSupply {
         self.0
     }


### PR DESCRIPTION
As a first pass I'd like to try and get nice type checker traces


Current output for this program
```
struct Box[a] {
    value: a
}

fn main() -> i32 {
    let b = Box#[i32]{ value = 42 };
    b.value
}
```
```
2024-07-13T09:05:14.894978Z  INFO compile_program:check{expr="49..101" expected="i32"}:infer{expr="63..86"}:infer{expr="82..85"}: frontend::types::check: Inferred type: i32
2024-07-13T09:05:14.895012Z  INFO compile_program:check{expr="49..101" expected="i32"}:infer{expr="63..86"}: frontend::types::check: Inferred type: Box[i32]
2024-07-13T09:05:14.895037Z  INFO compile_program:check{expr="49..101" expected="i32"}:infer{expr="87..99"}:infer{expr="87..93"}: frontend::types::check: Inferred type: Box[i32]
2024-07-13T09:05:14.895043Z  INFO compile_program:check{expr="49..101" expected="i32"}:infer{expr="87..99"}: frontend::types::check: Inferred type: i32
2024-07-13T09:05:14.895049Z  INFO compile_program:check{expr="49..101" expected="i32"}: frontend::types::check: ✔︎
```