### PR TITLE
Infer instantiations again

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -391,7 +391,7 @@ impl<'a> Codegen<'a> {
 
                 // Splat captures into locals
                 for (idx, (name, ty)) in captures.iter().enumerate() {
-                    let local = body_builder.new_local(*name, self.builder.val_ty(&ty));
+                    let local = body_builder.new_local(*name, self.builder.val_ty(ty));
                     lambda_instrs.push(Instruction::LocalGet(env_local));
                     lambda_instrs.push(Instruction::StructGet {
                         struct_type_index: concrete_closure_ty,

--- a/crates/backend/src/wasm_builder.rs
+++ b/crates/backend/src/wasm_builder.rs
@@ -550,7 +550,7 @@ impl<'a> Builder<'a> {
             })),
             mutable: false,
         }];
-        fields.extend(captures.into_iter().map(|t| FieldType {
+        fields.extend(captures.iter().map(|t| FieldType {
             // Careful! May change self.types length
             element_type: StorageType::Val(self.val_ty(t)),
             mutable: false,

--- a/crates/frontend/src/ir/format.rs
+++ b/crates/frontend/src/ir/format.rs
@@ -83,7 +83,7 @@ impl Formatter<'_> {
                     Callee::FuncRef(e) => elems.push(self.expr(e)),
                     Callee::Builtin(s) => elems.push(Value::string(*s)),
                 }
-                elems.extend(arguments.into_iter().map(|e| self.expr(e)));
+                elems.extend(arguments.iter().map(|e| self.expr(e)));
                 Value::list(elems)
             }
             ExprData::Binary { op, left, right } => Value::list(vec![
@@ -93,7 +93,7 @@ impl Formatter<'_> {
             ]),
             ExprData::Array { elems } => {
                 let mut els = vec![Value::symbol("array")];
-                els.extend(elems.into_iter().map(|e| self.expr(e)));
+                els.extend(elems.iter().map(|e| self.expr(e)));
                 Value::list(els)
             }
             ExprData::ArrayIdx { array, index } => Value::list(vec![
@@ -113,7 +113,7 @@ impl Formatter<'_> {
             ]),
             ExprData::Block { declarations, expr } => {
                 let mut elems = vec![Value::symbol("block")];
-                elems.extend(declarations.into_iter().map(|d| self.decl(d)));
+                elems.extend(declarations.iter().map(|d| self.decl(d)));
                 elems.push(self.expr(expr));
                 Value::list(elems)
             }
@@ -121,7 +121,7 @@ impl Formatter<'_> {
                 let mut elems = vec![self.name(name)];
                 elems.extend(
                     fields
-                        .into_iter()
+                        .iter()
                         .map(|(name, expr)| Value::from((self.name(name), self.expr(expr)))),
                 );
                 Value::list(elems)
@@ -141,12 +141,12 @@ impl Formatter<'_> {
                 let mut elems = vec![Value::symbol("lambda")];
                 elems.push(Value::vector(
                     captures
-                        .into_iter()
+                        .iter()
                         .map(|(n, ty)| Value::from((self.name(n), self.ty(ty)))),
                 ));
                 elems.push(Value::list(
                     params
-                        .into_iter()
+                        .iter()
                         .map(|(n, ty)| Value::from((self.name(n), self.ty(ty)))),
                 ));
                 elems.push(self.ty(return_ty));

--- a/crates/frontend/src/ir/names.rs
+++ b/crates/frontend/src/ir/names.rs
@@ -50,6 +50,7 @@ pub struct NameSupply {
     typ: u32,
     typ_var: u32,
     field: u32,
+    gen: u32,
     pub name_map: HashMap<Name, Id>,
 }
 
@@ -97,6 +98,19 @@ impl NameSupply {
         self.field += 1;
         let name = Name::Field(self.field);
         self.name_map.insert(name, id);
+        name
+    }
+
+    pub fn gen_idx(&mut self) -> Name {
+        self.gen += 1;
+        let name = Name::Gen(self.gen);
+        self.name_map.insert(
+            name,
+            Id {
+                it: format!("gen{}", self.gen),
+                at: TextRange::default(),
+            },
+        );
         name
     }
 

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -8,7 +8,6 @@ pub mod types;
 
 use parser::parse_prog;
 
-use crate::ir::format::format_ir;
 pub use error::CheckError;
 pub use types::CheckResult;
 
@@ -29,9 +28,6 @@ pub fn run_frontend(source: &str) -> CheckResult<CheckError> {
     if errors.is_empty() && check_result.ir.is_none() {
         panic!("No IR generated, despite no errors")
     };
-    if let Some(ir) = &check_result.ir {
-        println!("{}", format_ir(&check_result.names, ir));
-    }
 
     CheckResult {
         errors,

--- a/crates/frontend/src/types/error.rs
+++ b/crates/frontend/src/types/error.rs
@@ -139,6 +139,7 @@ pub enum TyErrorData {
     CantReassignCapturedVariable(Name),
     ArgCountMismatch(usize, usize),
     TyArgCountMismatch(usize, usize),
+    CantInferTypeParam(Name),
     FieldTypeMismatch {
         struct_name: Name,
         field_name: Name,
@@ -193,6 +194,7 @@ fn code_for_error(err_data: &TyErrorData) -> i32 {
         TyErrorData::TypeParamInVariantStruct => 23,
         TyErrorData::CantReturnFromGlobal => 24,
         TyErrorData::CantReassignCapturedVariable(_) => 25,
+        TyErrorData::CantInferTypeParam(_) => 26,
     }
 }
 
@@ -293,6 +295,9 @@ fn error_label(err_data: &TyErrorData, name_map: &NameMap) -> String {
         TyErrorData::CantReassignCapturedVariable(n) => {
             format!("Can't reassign the captured variable '{}'. Maybe you want to box this variable in a struct?", name_map.get(n).unwrap().it)
         }
+        TyErrorData::CantInferTypeParam(n) => {
+            format!("Can't infer type parameter '{}'. Explicitly supply the instantiation", name_map.get(n).unwrap().it)
+        },
     }
 }
 

--- a/crates/frontend/src/types/error.rs
+++ b/crates/frontend/src/types/error.rs
@@ -327,5 +327,5 @@ pub fn render_ty_error(
         .write(cache, &mut out_buf)
         .unwrap();
 
-    writeln!(output, "{}", str::from_utf8(&out_buf).unwrap()).unwrap();
+    write!(output, "{}", str::from_utf8(&out_buf).unwrap()).unwrap();
 }

--- a/crates/frontend/src/types/names.rs
+++ b/crates/frontend/src/types/names.rs
@@ -45,6 +45,10 @@ impl NameSupply {
         self.0.field_idx(token_into_id(field))
     }
 
+    pub fn gen_idx(&mut self) -> Name {
+        self.0.gen_idx()
+    }
+
     pub fn start_idx(&mut self) -> Name {
         self.0.func_idx(Id {
             it: "$start".to_string(),

--- a/crates/frontend/tests/lib.rs
+++ b/crates/frontend/tests/lib.rs
@@ -21,7 +21,7 @@ fn normalize_newlines(src: &mut String) {
     // directly, let's rather steal the contents of `src`. This makes the code
     // safe even if a panic occurs.
 
-    let mut buf = std::mem::replace(src, String::new()).into_bytes();
+    let mut buf = std::mem::take(src).into_bytes();
     let mut gap_len = 0;
     let mut tail = buf.as_mut_slice();
     loop {
@@ -63,7 +63,7 @@ fn normalize_newlines(src: &mut String) {
 }
 
 fn snapshot_type_errors(path: &Path, source: &str) -> String {
-    let CheckResult { names, errors, .. } = run_frontend(&source);
+    let CheckResult { names, errors, .. } = run_frontend(source);
     if errors
         .iter()
         .any(|e| matches!(e, CheckError::ParseError(_)))
@@ -82,7 +82,7 @@ fn snapshot_type_errors(path: &Path, source: &str) -> String {
         write!(
             &mut err_buf,
             "{}",
-            error.display(&source, &names.name_map, false)
+            error.display(source, &names.name_map, false)
         )
         .unwrap();
     }

--- a/crates/frontend/tests/snapshots/lib__type_errors@arg_count_mismatch.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@arg_count_mismatch.nemo.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/frontend/tests/lib.rs
-assertion_line: 104
 expression: output
 input_file: crates/frontend/tests/type_errors/arg_count_mismatch.nemo
 ---
@@ -11,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/arg_count_mismatch.nemo
    │       ────┬────  
    │           ╰────── Mismatched arg count. Expected 1 argument, but got 3
 ───╯
-
 [11] Error: Mismatched arg count. Expected 2 arguments, but got 3
    ╭─[source:1:13]
    │

--- a/crates/frontend/tests/snapshots/lib__type_errors@cant_infer_type_param.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@cant_infer_type_param.nemo.snap
@@ -1,0 +1,33 @@
+---
+source: crates/frontend/tests/lib.rs
+expression: output
+input_file: crates/frontend/tests/type_errors/cant_infer_type_param.nemo
+---
+[17] Error: Can't infer type of an empty array
+    ╭─[source:1:13]
+    │
+ 11 │   let s = S { a = 10, b = [] };
+    │                           ─┬  
+    │                            ╰── Can't infer type of an empty array
+────╯
+[26] Error: Can't infer type parameter 'b'. Explicitly supply the instantiation
+    ╭─[source:1:13]
+    │
+ 11 │   let s = S { a = 10, b = [] };
+    │           ┬  
+    │           ╰── Can't infer type parameter 'b'. Explicitly supply the instantiation
+────╯
+[17] Error: Can't infer type of an empty array
+    ╭─[source:1:13]
+    │
+ 12 │   polyF(10, []);
+    │             ─┬  
+    │              ╰── Can't infer type of an empty array
+────╯
+[26] Error: Can't infer type parameter 'b'. Explicitly supply the instantiation
+    ╭─[source:1:13]
+    │
+ 12 │   polyF(10, []);
+    │   ──┬──  
+    │     ╰──── Can't infer type parameter 'b'. Explicitly supply the instantiation
+────╯

--- a/crates/frontend/tests/snapshots/lib__type_errors@cant_instantiate_function_ref.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@cant_instantiate_function_ref.nemo.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/frontend/tests/lib.rs
-assertion_line: 104
 expression: output
 input_file: crates/frontend/tests/type_errors/cant_instantiate_function_ref.nemo
 ---
@@ -11,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/cant_instantiate_function_ref.nemo
    │               ─┬  
    │                ╰── Unknown variable id
 ───╯
-
 [21] Error: Can't instantiate function reference. Only top-level functions may be polymorphic at this time.
    ╭─[source:1:13]
    │

--- a/crates/frontend/tests/snapshots/lib__type_errors@cant_return_from_global.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@cant_return_from_global.nemo.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/frontend/tests/lib.rs
-assertion_line: 105
 expression: output
 input_file: crates/frontend/tests/type_errors/cant_return_from_global.nemo
 ---
@@ -11,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/cant_return_from_global.nemo
    │            ────┬───  
    │                ╰───── Can't 'return' from a global definition.
 ───╯
-
 [24] Error: Can't 'return' from a global definition.
    ╭─[source:1:13]
    │

--- a/crates/frontend/tests/snapshots/lib__type_errors@field_type_mismatch.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@field_type_mismatch.nemo.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/frontend/tests/lib.rs
-assertion_line: 104
 expression: output
 input_file: crates/frontend/tests/type_errors/field_type_mismatch.nemo
 ---
@@ -10,12 +9,4 @@ input_file: crates/frontend/tests/type_errors/field_type_mismatch.nemo
  6 │   F { x = true }
    │           ──┬──  
    │             ╰──── Type mismatch. Expected i32, but got bool
-───╯
-
-[15] Error: Type mismatch. Expected unit, but got F
-   ╭─[source:2:2]
-   │
- 6 │   F { x = true }
-   │   ───────┬──────  
-   │          ╰──────── Type mismatch. Expected unit, but got F
 ───╯

--- a/crates/frontend/tests/snapshots/lib__type_errors@field_type_mismatch.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@field_type_mismatch.nemo.snap
@@ -10,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/field_type_mismatch.nemo
    │           ──┬──  
    │             ╰──── Type mismatch. Expected i32, but got bool
 ───╯
-
 [15] Error: Type mismatch. Expected unit, but got F
    ╭─[source:2:2]
    │

--- a/crates/frontend/tests/snapshots/lib__type_errors@field_type_mismatch.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@field_type_mismatch.nemo.snap
@@ -10,3 +10,11 @@ input_file: crates/frontend/tests/type_errors/field_type_mismatch.nemo
    │           ──┬──  
    │             ╰──── Type mismatch. Expected i32, but got bool
 ───╯
+
+[15] Error: Type mismatch. Expected unit, but got F
+   ╭─[source:2:2]
+   │
+ 6 │   F { x = true }
+   │   ───────┬──────  
+   │          ╰──────── Type mismatch. Expected unit, but got F
+───╯

--- a/crates/frontend/tests/snapshots/lib__type_errors@lambda.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@lambda.nemo.snap
@@ -10,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/lambda.nemo
    │              ─┬  
    │               ╰── Type mismatch. Expected f32, but got i32
 ───╯
-
 [15] Error: Type mismatch. Expected i32, but got f32
    ╭─[source:1:13]
    │

--- a/crates/frontend/tests/snapshots/lib__type_errors@non_struct_idx.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@non_struct_idx.nemo.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/frontend/tests/lib.rs
-assertion_line: 104
 expression: output
 input_file: crates/frontend/tests/type_errors/non_struct_idx.nemo
 ---
@@ -11,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/non_struct_idx.nemo
    │      ┬  
    │      ╰── Tried to index into a non-struct type i32
 ───╯
-
 [10] Error: Tried to index into a non-struct type i32
    ╭─[source:2:1]
    │

--- a/crates/frontend/tests/snapshots/lib__type_errors@return_type_mismatch.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@return_type_mismatch.nemo.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/frontend/tests/lib.rs
-assertion_line: 105
 expression: output
 input_file: crates/frontend/tests/type_errors/return_type_mismatch.nemo
 ---
@@ -11,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/return_type_mismatch.nemo
    │          ┬  
    │          ╰── Type mismatch. Expected unit, but got i32
 ───╯
-
 [15] Error: Type mismatch. Expected i32, but got unit
    ╭─[source:2:1]
    │

--- a/crates/frontend/tests/snapshots/lib__type_errors@ty_arg_count_mismatch.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@ty_arg_count_mismatch.nemo.snap
@@ -10,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/ty_arg_count_mismatch.nemo
     │   ──┬─  
     │     ╰─── Mismatched type arg count. Expected 2 arguments, but got 1
 ────╯
-
 [22] Error: Mismatched type arg count. Expected 2 arguments, but got 1
     ╭─[source:1:13]
     │
@@ -18,7 +17,6 @@ input_file: crates/frontend/tests/type_errors/ty_arg_count_mismatch.nemo
     │   ─────────────┬────────────  
     │                ╰────────────── Mismatched type arg count. Expected 2 arguments, but got 1
 ────╯
-
 [22] Error: Mismatched type arg count. Expected 1 argument, but got 2
     ╭─[source:1:13]
     │

--- a/crates/frontend/tests/snapshots/lib__type_errors@ty_arg_count_mismatch.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@ty_arg_count_mismatch.nemo.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/frontend/tests/lib.rs
-assertion_line: 104
 expression: output
 input_file: crates/frontend/tests/type_errors/ty_arg_count_mismatch.nemo
 ---
@@ -16,22 +15,14 @@ input_file: crates/frontend/tests/type_errors/ty_arg_count_mismatch.nemo
     ╭─[source:1:13]
     │
  16 │   Box#[i32] { a = 1, b = 2 };
-    │      ───┬──  
-    │         ╰──── Mismatched type arg count. Expected 2 arguments, but got 1
-────╯
-
-[15] Error: Type mismatch. Expected b, but got i32
-    ╭─[source:1:13]
-    │
- 16 │   Box#[i32] { a = 1, b = 2 };
-    │                          ─┬  
-    │                           ╰── Type mismatch. Expected b, but got i32
+    │   ─────────────┬────────────  
+    │                ╰────────────── Mismatched type arg count. Expected 2 arguments, but got 1
 ────╯
 
 [22] Error: Mismatched type arg count. Expected 1 argument, but got 2
     ╭─[source:1:13]
     │
  17 │   List::Nil#[i32, f32] {};
-    │            ─────┬─────  
-    │                 ╰─────── Mismatched type arg count. Expected 1 argument, but got 2
+    │   ───────────┬───────────  
+    │              ╰───────────── Mismatched type arg count. Expected 1 argument, but got 2
 ────╯

--- a/crates/frontend/tests/snapshots/lib__type_errors@type_mismatch.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@type_mismatch.nemo.snap
@@ -10,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/type_mismatch.nemo
    │                  ──┬─  
    │                    ╰─── Type mismatch. Expected i32, but got f32
 ───╯
-
 [15] Error: Type mismatch. Expected fn (i32) -> i32, but got fn (f32) -> f32
    ╭─[source:1:13]
    │

--- a/crates/frontend/tests/snapshots/lib__type_errors@unknown_alternative.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@unknown_alternative.nemo.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/frontend/tests/lib.rs
-assertion_line: 104
 expression: output
 input_file: crates/frontend/tests/type_errors/unknown_alternative.nemo
 ---
@@ -11,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/unknown_alternative.nemo
    │      ───┬───  
    │         ╰───── Unknown type Unknown
 ───╯
-
 [19] Error: Unknown alternative. V does not have an alternative named Unknown
    ╭─[source:2:1]
    │

--- a/crates/frontend/tests/snapshots/lib__type_errors@unknown_field.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@unknown_field.nemo.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/frontend/tests/lib.rs
-assertion_line: 104
 expression: output
 input_file: crates/frontend/tests/type_errors/unknown_field.nemo
 ---
@@ -11,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/unknown_field.nemo
    │               ┬  
    │               ╰── Unknown field. F does not have a field named y
 ───╯
-
 [13] Error: Unknown field. F does not have a field named y
    ╭─[source:2:2]
    │
@@ -19,7 +17,6 @@ input_file: crates/frontend/tests/type_errors/unknown_field.nemo
    │                        ┬  
    │                        ╰── Unknown field. F does not have a field named y
 ───╯
-
 [13] Error: Unknown field. F does not have a field named y
    ╭─[source:2:2]
    │

--- a/crates/frontend/tests/snapshots/lib__type_errors@unknown_var.nemo.snap
+++ b/crates/frontend/tests/snapshots/lib__type_errors@unknown_var.nemo.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/frontend/tests/lib.rs
-assertion_line: 104
 expression: output
 input_file: crates/frontend/tests/type_errors/unknown_var.nemo
 ---
@@ -11,7 +10,6 @@ input_file: crates/frontend/tests/type_errors/unknown_var.nemo
    │   ───┬───  
    │      ╰───── Unknown variable unknown
 ───╯
-
 [05] Error: Unknown variable unknown
    ╭─[source:2:1]
    │
@@ -19,7 +17,6 @@ input_file: crates/frontend/tests/type_errors/unknown_var.nemo
    │       ───┬───  
    │          ╰───── Unknown variable unknown
 ───╯
-
 [05] Error: Unknown variable unknown
    ╭─[source:2:1]
    │

--- a/crates/frontend/tests/type_errors/cant_infer_type_param.nemo
+++ b/crates/frontend/tests/type_errors/cant_infer_type_param.nemo
@@ -1,0 +1,14 @@
+struct S[a, b] {
+    a : a,
+    b : b,
+}
+
+fn polyF[a, b](x : a, y : b) -> a {
+    x
+}
+
+fn main() {
+  let s = S { a = 10, b = [] };
+  polyF(10, []);
+  {}
+}

--- a/justfile
+++ b/justfile
@@ -14,11 +14,11 @@ build-wasm-lib:
 
 run-wasm FILE:
     mkdir -p build
-    cargo run --bin nemo compile {{ FILE }} --output build/{{ without_extension(FILE) }}.wasm
-    wasm-opt --enable-reference-types --enable-gc -O3 build/{{ without_extension(FILE) }}.wasm -o build/{{ without_extension(FILE) }}_opt.wasm
-    wasm-tools print build/{{ without_extension(FILE) }}.wasm -o build/{{ without_extension(FILE) }}.wast
-    wasm-tools print build/{{ without_extension(FILE) }}_opt.wasm -o build/{{ without_extension(FILE) }}_opt.wast
-    node dev/run-wasm.mjs build/{{ without_extension(FILE) }}.wasm
+    cargo run --bin nemo compile {{ FILE }} --output build/{{ without_extension(file_name(FILE)) }}.wasm
+    wasm-opt --enable-reference-types --enable-gc -O3 build/{{ without_extension(file_name(FILE)) }}.wasm -o build/{{ without_extension(file_name(FILE)) }}_opt.wasm
+    wasm-tools print build/{{ without_extension(file_name(FILE)) }}.wasm -o build/{{ without_extension(file_name(FILE)) }}.wast
+    wasm-tools print build/{{ without_extension(file_name(FILE)) }}_opt.wasm -o build/{{ without_extension(file_name(FILE)) }}_opt.wast
+    node dev/run-wasm.mjs build/{{ without_extension(file_name(FILE)) }}.wasm
 
 dev FILE:
     RUST_BACKTRACE=1 watchexec --quiet -e nemo,rs just run-wasm {{ FILE }}

--- a/playground/examples/bst.nemo
+++ b/playground/examples/bst.nemo
@@ -3,18 +3,18 @@
 fn main() {
   let tree : Bst[i32, f32] = Bst {
     compare = compare_i32,
-    root = leaf#[i32, f32] (10, 3.14),
+    root = leaf(10, 3.14),
   };
 
-  while size#[i32, f32](tree) < 50 {
+  while size(tree) < 50 {
     let key = random_int(0, 100);
     let value = random();
-    set tree = insert#[i32, f32](tree, key, value);
+    set tree = insert(tree, key, value);
   };
 
   let i = 1;
   while i < 100 {
-    match lookup#[i32, f32](tree, i) {
+    match lookup(tree, i) {
       Option::None _ => { log_f32(0.0 - 1.0) },
       Option::Some found => { log_f32(found.value) },
     };
@@ -81,7 +81,7 @@ fn insert_node[k, v](
           Node {
             key = node.key,
             value = node.value,
-            left = leaf#[k, v](key, value),
+            left = leaf(key, value),
             right = node.right,
           }
         },
@@ -90,7 +90,7 @@ fn insert_node[k, v](
             key = node.key,
             value = node.value,
             left = Option::Some {
-              value = insert_node#[k, v](left.value, compare, key, value)
+              value = insert_node(left.value, compare, key, value)
             },
             right = node.right,
           }
@@ -104,7 +104,7 @@ fn insert_node[k, v](
             key = key,
             value = value,
             left = node.left,
-            right = leaf#[k, v](key, value),
+            right = leaf(key, value),
           }
         },
         Option::Some right => {
@@ -113,7 +113,7 @@ fn insert_node[k, v](
             value = node.value,
             left = node.left,
             right = Option::Some {
-              value = insert_node#[k, v](right.value, compare, key, value)
+              value = insert_node(right.value, compare, key, value)
             },
           }
         }
@@ -127,14 +127,14 @@ fn insert[k, v](tree : Bst[k, v], key : k, value : v) -> Bst[k, v] {
     Option::None _ => {
       Bst {
         compare = tree.compare,
-        root = leaf #[k, v](key, value),
+        root = leaf(key, value),
       }
     },
     Option::Some root => {
       Bst {
         compare = tree.compare,
         root = Option::Some {
-          value = insert_node #[k, v] (root.value, tree.compare, key, value),
+          value = insert_node(root.value, tree.compare, key, value),
         },
       }
     }
@@ -184,18 +184,18 @@ fn compare_i32(a : i32, b : i32) -> Ordering {
 fn size[k, v](tree : Bst[k, v]) -> i32 {
   match tree.root {
     Option::None _ => { 0 },
-    Option::Some root => { size_node#[k, v](root.value) },
+    Option::Some root => { size_node(root.value) },
   }
 }
 
 fn size_node[k, v](node : Node[k, v]) -> i32 {
   let left = match node.left {
     Option::None _ => { 0 },
-    Option::Some n => { size_node#[k, v](n.value) },
+    Option::Some n => { size_node(n.value) },
   };
   let right = match node.right {
     Option::None _ => { 0 },
-    Option::Some n => { size_node#[k, v](n.value) },
+    Option::Some n => { size_node(n.value) },
   };
   1 + left + right
 }

--- a/playground/examples/bst.nemo
+++ b/playground/examples/bst.nemo
@@ -1,7 +1,7 @@
-// Inserts random numbers from 0 to 100 into a binary search tree until it 
+// Inserts random numbers from 0 to 100 into a binary search tree until it
 // reaches size 50, then looks up the values for 1, 11, 21, ..., 91
 fn main() {
-  let tree = Bst #[i32, f32] {
+  let tree : Bst[i32, f32] = Bst {
     compare = compare_i32,
     root = leaf#[i32, f32] (10, 3.14),
   };
@@ -50,25 +50,25 @@ struct Node[k, v] {
 }
 
 fn leaf[k, v](key : k, value : v) -> Option[Node[k, v]] {
-  Option::Some #[Node[k, v]] {
-    value = Node #[k, v] {
+  Option::Some {
+    value = Node {
       key = key,
       value = value,
-      left = Option::None #[Node[k, v]] {},
-      right = Option::None #[Node[k, v]] {},
+      left = Option::None {},
+      right = Option::None {},
     }
   }
 }
 
 fn insert_node[k, v](
-  node : Node[k, v], 
-  compare : fn(k, k) -> Ordering, 
-  key : k, 
+  node : Node[k, v],
+  compare : fn(k, k) -> Ordering,
+  key : k,
   value : v
 ) -> Node[k, v] {
   match compare(key, node.key) {
     Ordering::Eq _ => {
-      Node #[k, v] {
+      Node {
         key = key,
         value = value,
         left = node.left,
@@ -78,7 +78,7 @@ fn insert_node[k, v](
     Ordering::Lt _ => {
       match node.left {
         Option::None _ => {
-          Node #[k, v] {
+          Node {
             key = node.key,
             value = node.value,
             left = leaf#[k, v](key, value),
@@ -86,11 +86,11 @@ fn insert_node[k, v](
           }
         },
         Option::Some left => {
-          Node #[k, v] {
+          Node {
             key = node.key,
             value = node.value,
-            left = Option::Some #[Node[k, v]] {
-              value = insert_node#[k, v](left.value, compare, key, value) 
+            left = Option::Some {
+              value = insert_node#[k, v](left.value, compare, key, value)
             },
             right = node.right,
           }
@@ -100,7 +100,7 @@ fn insert_node[k, v](
     Ordering::Gt _ => {
       match node.right {
         Option::None _ => {
-          Node #[k, v] {
+          Node {
             key = key,
             value = value,
             left = node.left,
@@ -108,12 +108,12 @@ fn insert_node[k, v](
           }
         },
         Option::Some right => {
-          Node #[k, v] {
+          Node {
             key = node.key,
             value = node.value,
             left = node.left,
-            right = Option::Some #[Node[k, v]] {
-              value = insert_node#[k, v](right.value, compare, key, value) 
+            right = Option::Some {
+              value = insert_node#[k, v](right.value, compare, key, value)
             },
           }
         }
@@ -125,15 +125,15 @@ fn insert_node[k, v](
 fn insert[k, v](tree : Bst[k, v], key : k, value : v) -> Bst[k, v] {
   match tree.root {
     Option::None _ => {
-      Bst #[k, v] {
+      Bst {
         compare = tree.compare,
-        root = leaf #[k, v] (key, value),
+        root = leaf #[k, v](key, value),
       }
     },
     Option::Some root => {
-      Bst#[k, v] {
+      Bst {
         compare = tree.compare,
-        root = Option::Some #[Node[k, v]] {
+        root = Option::Some {
           value = insert_node #[k, v] (root.value, tree.compare, key, value),
         },
       }
@@ -143,7 +143,7 @@ fn insert[k, v](tree : Bst[k, v], key : k, value : v) -> Bst[k, v] {
 
 fn lookup[k, v](tree : Bst[k, v], key : k) -> Option[v] {
   let current = tree.root;
-  let result = Option::None #[v] {};
+  let result : Option[v] = Option::None {};
   let keep_going = true;
   while keep_going {
     match current {
@@ -159,7 +159,7 @@ fn lookup[k, v](tree : Bst[k, v], key : k) -> Option[v] {
             set current = node.value.right;
           },
           Ordering::Eq _ => {
-            set result = Option::Some #[v] { value = node.value.value };
+            set result = Option::Some { value = node.value.value };
             set keep_going = false;
           },
         }
@@ -172,7 +172,7 @@ fn lookup[k, v](tree : Bst[k, v], key : k) -> Option[v] {
 fn compare_i32(a : i32, b : i32) -> Ordering {
   if a < b {
     Ordering::Lt {}
-  } else { 
+  } else {
     if a > b {
       Ordering::Gt {}
     } else {

--- a/playground/examples/closure.nemo
+++ b/playground/examples/closure.nemo
@@ -5,7 +5,7 @@ fn main() -> i32 {
     let add15 = fn (z : i32) -> i32 {
       x + y + z
     };
-    twice#[i32](add15)(12);
+    twice(add15)(12);
 }
 
 fn twice[a](f : fn(a) -> a) -> fn (a) -> a {

--- a/playground/examples/list.nemo
+++ b/playground/examples/list.nemo
@@ -20,10 +20,10 @@ variant List[a] {
 
 fn map[a, b](f : fn (a) -> b, as : List[a]) -> List[b] {
   match as {
-    List::Nil l => { List::Nil#[b] {} },
+    List::Nil l => { List::Nil {} },
     List::Cons l => {
       let new_head = f(l.head);
-      List::Cons#[b] {
+      List::Cons {
         head = new_head,
         tail = map#[a, b](f, l.tail)
       }
@@ -44,9 +44,9 @@ fn for_each[a](f : fn (a) -> unit, as : List[a]) {
 }
 
 fn range(lo : i32, hi : i32) -> List[i32] {
-  let result = List::Nil#[i32]{};
+  let result : List[i32] = List::Nil {};
   while lo < hi {
-    set result = List::Cons#[i32] { head = hi, tail = result };
+    set result = List::Cons { head = hi, tail = result };
     set hi = hi - 1
   };
   result


### PR DESCRIPTION
- [x] "Infers" struct instantiations when in checking mode
  This doesn't actually do any inference, it just uses the instantiation we're checking against. Very effective though, as it removes basically all manual struct instantations in `bst.nemo`
- [x] Infers instantiations by using a local matching algorithm (limited one-sided unification). When inferring instantiations for functions we should also use a potential return type we're checking against
- [x] Match/field based inference for struct literals