### PR TITLE
WIP: allows multiple return values for functions

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -256,7 +256,7 @@ impl<'a> Codegen<'a> {
                         instrs.extend(self.compile_expr(body, expr));
                         instrs.push(Instruction::I32Const(-1));
                         instrs.push(Instruction::I32Xor);
-                    },
+                    }
                     UnOpData::I32Neg => {
                         instrs.push(Instruction::I32Const(0));
                         instrs.extend(self.compile_expr(body, expr));

--- a/crates/frontend/src/builtins.rs
+++ b/crates/frontend/src/builtins.rs
@@ -14,7 +14,7 @@ fn f32_func_unary(name: &'static str) -> Fn {
         ty_params: vec![],
         ty: FuncTy {
             arguments: vec![Ty::F32],
-            result: Ty::F32,
+            results: vec![Ty::F32],
         },
     }
 }
@@ -25,7 +25,7 @@ fn f32_func_binary(name: &'static str) -> Fn {
         ty_params: vec![],
         ty: FuncTy {
             arguments: vec![Ty::F32, Ty::F32],
-            result: Ty::F32,
+            results: vec![Ty::F32],
         },
     }
 }
@@ -36,7 +36,7 @@ fn i32_func_unary(name: &'static str) -> Fn {
         ty_params: vec![],
         ty: FuncTy {
             arguments: vec![Ty::I32],
-            result: Ty::I32,
+            results: vec![Ty::I32],
         },
     }
 }
@@ -47,7 +47,7 @@ fn u32_func_unary(name: &'static str) -> Fn {
         ty_params: vec![],
         ty: FuncTy {
             arguments: vec![Ty::U32],
-            result: Ty::U32,
+            results: vec![Ty::U32],
         },
     }
 }
@@ -58,7 +58,7 @@ fn i32_func_binary(name: &'static str) -> Fn {
         ty_params: vec![],
         ty: FuncTy {
             arguments: vec![Ty::I32, Ty::I32],
-            result: Ty::I32,
+            results: vec![Ty::I32],
         },
     }
 }
@@ -69,7 +69,7 @@ fn u32_func_binary(name: &'static str) -> Fn {
         ty_params: vec![],
         ty: FuncTy {
             arguments: vec![Ty::U32, Ty::U32],
-            result: Ty::U32,
+            results: vec![Ty::U32],
         },
     }
 }
@@ -100,7 +100,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::I32],
-                result: Ty::F32,
+                results: vec![Ty::F32],
             },
         },
     );
@@ -111,7 +111,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::U32],
-                result: Ty::F32,
+                results: vec![Ty::F32],
             },
         },
     );
@@ -148,7 +148,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::F32],
-                result: Ty::I32,
+                results: vec![Ty::I32],
             },
         },
     );
@@ -159,7 +159,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::F32],
-                result: Ty::U32,
+                results: vec![Ty::U32],
             },
         },
     );
@@ -170,7 +170,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::F32],
-                result: Ty::I32,
+                results: vec![Ty::I32],
             },
         },
     );
@@ -181,7 +181,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::I32],
-                result: Ty::U32,
+                results: vec![Ty::U32],
             },
         },
     );
@@ -192,7 +192,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::U32],
-                result: Ty::I32,
+                results: vec![Ty::I32],
             },
         },
     );
@@ -203,7 +203,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![TODO_NAME],
             ty: FuncTy {
                 arguments: vec![Ty::Array(Box::new(Ty::Var(TODO_NAME)))],
-                result: Ty::I32,
+                results: vec![Ty::I32],
             },
         },
     );
@@ -214,7 +214,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![TODO_NAME],
             ty: FuncTy {
                 arguments: vec![Ty::Var(TODO_NAME), Ty::I32],
-                result: Ty::Array(Box::new(Ty::Var(TODO_NAME))),
+                results: vec![Ty::Array(Box::new(Ty::Var(TODO_NAME)))],
             },
         },
     );
@@ -231,7 +231,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
                     Ty::I32,
                     Ty::I32,
                 ],
-                result: Ty::Unit,
+                results: vec![Ty::Unit],
             },
         },
     );
@@ -242,7 +242,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::Bytes, Ty::I32],
-                result: Ty::I32,
+                results: vec![Ty::I32],
             },
         },
     );
@@ -253,7 +253,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::Bytes, Ty::I32, Ty::I32],
-                result: Ty::Unit,
+                results: vec![Ty::Unit],
             },
         },
     );
@@ -264,7 +264,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::Bytes],
-                result: Ty::I32,
+                results: vec![Ty::I32],
             },
         },
     );
@@ -275,7 +275,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::I32, Ty::I32],
-                result: Ty::Bytes,
+                results: vec![Ty::Bytes],
             },
         },
     );
@@ -286,7 +286,7 @@ static BUILTINS: LazyLock<HashMap<&'static str, Fn>> = LazyLock::new(|| {
             ty_params: vec![],
             ty: FuncTy {
                 arguments: vec![Ty::Bytes, Ty::I32, Ty::Bytes, Ty::I32, Ty::I32],
-                result: Ty::Unit,
+                results: vec![Ty::Unit],
             },
         },
     );

--- a/crates/frontend/src/ir.rs
+++ b/crates/frontend/src/ir.rs
@@ -57,7 +57,9 @@ impl Ty {
                 for t in &func_ty.arguments {
                     t.vars_inner(acc)
                 }
-                func_ty.result.vars_inner(acc)
+                for t in &func_ty.results {
+                    t.vars_inner(acc)
+                }
             }
         }
     }
@@ -112,7 +114,7 @@ impl fmt::Display for TyDisplay<'_> {
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct FuncTy {
     pub arguments: Vec<Ty>,
-    pub result: Ty,
+    pub results: Vec<Ty>,
 }
 
 impl FuncTy {
@@ -137,7 +139,12 @@ impl fmt::Display for FuncTyDisplay<'_> {
                 .map(|a| format!("{}", a.display(self.ctx)))
                 .collect::<Vec<String>>()
                 .join(", "),
-            self.func_ty.result.display(self.ctx)
+            self.func_ty
+                .results
+                .iter()
+                .map(|a| format!("{}", a.display(self.ctx)))
+                .collect::<Vec<String>>()
+                .join(", "),
         )
     }
 }
@@ -198,7 +205,7 @@ impl Substitution {
         }
         FuncTy {
             arguments: ty.arguments.into_iter().map(|t| self.apply(t)).collect(),
-            result: self.apply(ty.result),
+            results: ty.results.into_iter().map(|t| self.apply(t)).collect(),
         }
     }
 
@@ -638,7 +645,7 @@ pub struct Func {
     pub name: Name,
     pub ty_params: Vec<Name>,
     pub params: Vec<(Name, Ty)>,
-    pub return_ty: Ty,
+    pub return_tys: Vec<Ty>,
     pub body: Expr,
 }
 
@@ -646,7 +653,7 @@ impl Func {
     pub fn func_ty(&self) -> FuncTy {
         FuncTy {
             arguments: self.params.iter().map(|(_, t)| t.clone()).collect(),
-            result: self.return_ty.clone(),
+            results: self.return_tys.clone(),
         }
     }
     pub fn is_monomorphic(&self) -> bool {

--- a/crates/frontend/src/parser/grammar.rs
+++ b/crates/frontend/src/parser/grammar.rs
@@ -204,7 +204,7 @@ fn top_func(p: &mut Parser) {
     }
     typ_param_list(p);
     param_list(p, TypAnnot::Required);
-    if p.eat(T![->]) && !typ(p).made_progress() {
+    if p.eat(T![->]) && !ty_result_list(p).made_progress() {
         p.error("expected a return type")
     }
     if !block_expr(p).made_progress() {
@@ -251,6 +251,19 @@ fn param_list(p: &mut Parser, typ_annot_opt: TypAnnot) {
         // TODO recover
     }
     p.finish_at(c, SyntaxKind::ParamList);
+}
+
+fn ty_result_list(p: &mut Parser) -> Progress {
+    let c = p.checkpoint();
+    let mut progress = Progress::None;
+    while typ(p).made_progress() {
+        progress = Progress::Made;
+        if !p.eat(SyntaxKind::COMMA) {
+            break;
+        }
+    }
+    p.finish_at(c, SyntaxKind::TyResultList);
+    progress
 }
 
 fn qualifier(p: &mut Parser) -> Progress {
@@ -338,7 +351,7 @@ fn typ(p: &mut Parser) -> Progress {
             p.expect(T![')']);
             p.finish_at(c_arg, SyntaxKind::TyArgList);
             p.expect(T![->]);
-            if !typ(p).made_progress() {
+            if !ty_result_list(p).made_progress() {
                 p.error("expected a return type")
             }
             p.finish_at(c, SyntaxKind::TyFn)

--- a/crates/frontend/src/parser/lexer.rs
+++ b/crates/frontend/src/parser/lexer.rs
@@ -329,6 +329,7 @@ pub enum SyntaxKind {
     UnOp,
     BinOp,
     TyArgList,
+    TyResultList,
     EArgList,
     ETyArgList,
     Qualifier,

--- a/crates/frontend/src/syntax/nodes.rs
+++ b/crates/frontend/src/syntax/nodes.rs
@@ -189,10 +189,7 @@ impl TopFn {
     pub fn param_list(&self) -> Option<ParamList> {
         support::child(&self.syntax)
     }
-    pub fn arrow_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, T![->])
-    }
-    pub fn ty(&self) -> Option<Type> {
+    pub fn ty_result_list(&self) -> Option<TyResultList> {
         support::child(&self.syntax)
     }
     pub fn body(&self) -> Option<EBlock> {
@@ -247,6 +244,15 @@ pub struct ParamList {
 }
 impl ParamList {
     pub fn params(&self) -> AstChildren<Param> {
+        support::children(&self.syntax)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TyResultList {
+    pub(crate) syntax: SyntaxNode,
+}
+impl TyResultList {
+    pub fn types(&self) -> AstChildren<Type> {
         support::children(&self.syntax)
     }
 }
@@ -375,7 +381,7 @@ impl TyFn {
     pub fn arrow_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, T![->])
     }
-    pub fn result(&self) -> Option<Type> {
+    pub fn ty_result_list(&self) -> Option<TyResultList> {
         support::child(&self.syntax)
     }
 }
@@ -1131,6 +1137,21 @@ impl AstNode for StructField {
 impl AstNode for ParamList {
     fn can_cast(kind: SyntaxKind) -> bool {
         kind == ParamList
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        if Self::can_cast(syntax.kind()) {
+            Some(Self { syntax })
+        } else {
+            None
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        &self.syntax
+    }
+}
+impl AstNode for TyResultList {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == TyResultList
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2369,6 +2390,11 @@ impl std::fmt::Display for StructField {
     }
 }
 impl std::fmt::Display for ParamList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for TyResultList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/frontend/src/syntax/nodes.ungram
+++ b/crates/frontend/src/syntax/nodes.ungram
@@ -30,7 +30,7 @@ StructField = 'ident' ':' Type
 
 TopVariant = 'variant' 'upper_ident' type_params:ParamTy* '{' TopStruct* '}'
 
-TopFn = 'fn' 'ident' ParamTy* ParamList ('->' Type)? body:EBlock
+TopFn = 'fn' 'ident' ParamTy* ParamList TyResultList body:EBlock
 ParamList = Param*
 Param = 'ident' ':' Type
 ParamTy = 'ident'
@@ -59,8 +59,9 @@ TyVar = 'ident'
 ModQualifier = 'ident' '::'
 Qualifier = 'upper_ident' '::'
 
-TyFn = 'fn' TyArgList '->' result:Type
+TyFn = 'fn' TyArgList '->' TyResultList
 TyArgList = '(' Type* ')'
+TyResultList = Type*
 
 // Literals
 Literal = LitBool | LitFloat | LitInt | LitBytes


### PR DESCRIPTION
Tries to do so without adding first class tuples to the language. Doesn't really work nicely with "Block evaluates to last expression" as there are no tuple expressions. Could either require explicit return for multi-value functions, or expand to first class tuples (which would require dealing with heap allocated tuples).